### PR TITLE
Fix scan_index_forward: true -> false

### DIFF
--- a/lib/cred_stash.rb
+++ b/lib/cred_stash.rb
@@ -6,7 +6,7 @@ module CredStash
       table_name:  'credential-store',
       limit: 1,
       consistent_read: true,
-      scan_index_forward: true,
+      scan_index_forward: false,
       key_condition_expression: "#name = :name",
       expression_attribute_names: { "#name" => "name"},
       expression_attribute_values: { ":name" => name }


### PR DESCRIPTION
If scan_index_forward: true, will get the oldest version.

see https://github.com/fugue/credstash/blob/v1.11.0/credstash.py#L260
