### PR TITLE
add raise_if_missing parameter to CredStash.get()

### DIFF
--- a/lib/cred_stash.rb
+++ b/lib/cred_stash.rb
@@ -2,7 +2,7 @@ require 'aws-sdk'
 
 module CredStash
   class << self
-    def get(name, context: {})
+    def get(name, context: {}, raise_if_missing: false)
       secret = Secret.find(name, context: context)
 
       if secret.falsified?
@@ -11,7 +11,8 @@ module CredStash
 
       secret.decrypted_value
 
-    rescue CredStash::ItemNotFound
+    rescue CredStash::ItemNotFound => e
+      raise e if raise_if_missing
       nil
     end
 


### PR DESCRIPTION
A quick pass at offering the ability to actually raise an exception for a missing item. It defaults to false to preserve existing functionality, but passing `raise_if_missing: true` will re-raise the `CredStash::ItemNotFound` exception. 

I found it a bit jarring when I incorporated this gem and ended up with some empty strings in configuration because I had neglected to fill up my credstash db and thought the alternative would be better for my purposes -- since it is only a line or two change, feel free to reject and add this sort of feature in whatever way you'd prefer.

Thanks for the gem! It's wonderful to have a ruby spin!