### PR TITLE
added kms_key_id parameter to Secret

### DIFF
--- a/lib/cred_stash.rb
+++ b/lib/cred_stash.rb
@@ -16,9 +16,9 @@ module CredStash
       nil
     end
 
-    def put(name, value, context: {})
+    def put(name, value, kms_key_id: nil, context: {})
       secret = Secret.new(name: name, value: value, context: context)
-      secret.encrypt!
+      secret.encrypt!(kms_key_id: kms_key_id)
       secret.save
     end
 

--- a/lib/cred_stash/cipher_key.rb
+++ b/lib/cred_stash/cipher_key.rb
@@ -1,9 +1,10 @@
 class CredStash::CipherKey
   attr_reader :data_key, :hmac_key, :wrapped_key
 
-  def self.generate(client: Aws::KMS::Client.new, context: {})
+  def self.generate(client: Aws::KMS::Client.new, kms_key_id: 'alias/credstash',
+                    context: {})
     res = client.generate_data_key(
-      key_id: 'alias/credstash',
+      key_id: kms_key_id,
       number_of_bytes: 64,
       encryption_context: context
     )

--- a/lib/cred_stash/cipher_key.rb
+++ b/lib/cred_stash/cipher_key.rb
@@ -1,10 +1,12 @@
 class CredStash::CipherKey
+  DEFAULT_KMS_KEY_ID = "alias/credstash".freeze
+
   attr_reader :data_key, :hmac_key, :wrapped_key
 
-  def self.generate(client: Aws::KMS::Client.new, kms_key_id: 'alias/credstash',
+  def self.generate(client: Aws::KMS::Client.new, kms_key_id: nil,
                     context: {})
     res = client.generate_data_key(
-      key_id: kms_key_id,
+      key_id: kms_key_id || DEFAULT_KMS_KEY_ID,
       number_of_bytes: 64,
       encryption_context: context
     )

--- a/lib/cred_stash/secret.rb
+++ b/lib/cred_stash/secret.rb
@@ -10,8 +10,8 @@ class CredStash::Secret
     @context = context
   end
 
-  def encrypt!
-    @key = CredStash::CipherKey.generate(context: @context)
+  def encrypt!(kms_key_id: nil)
+    @key = CredStash::CipherKey.generate(kms_key_id: kms_key_id, context: @context)
     @encrypted_value = @key.encrypt(@value)
     @hmac = @key.hmac(@encrypted_value)
   end


### PR DESCRIPTION
We use a separate KMS key for every CloudFormation stack in our
environment, and so porting from Credstash to rcredstash hit a
snag because rcredstash forced the use of `alias/credstash`. This
pull request adds support for arbitrarily-named KMS keys.