### PR TITLE
Add dynamodb_local as storage option

### DIFF
--- a/lib/cred_stash/repository.rb
+++ b/lib/cred_stash/repository.rb
@@ -6,6 +6,13 @@ module CredStash::Repository
     case CredStash.config.storage
     when :dynamodb
       DynamoDB.new
+    when :dynamodb_local
+      endpoint = ENV['DYNAMODB_URL'] || 'http://localhost:8000'
+      DynamoDB.new(
+        client: Aws::DynamoDB::Client.new(
+          endpoint: endpoint,
+        )
+      )
     else
       raise ArgumentError, "Unknown storage #{CredStash.config.storage}"
     end


### PR DESCRIPTION
For codebases that disable HTTP connections during test runs, the
credstash config block will cause issues because it attempts to ping
live AWS DDB endpoint.

Adding `dynamodb_local` will allow developers to run end-to-end
integration tests using the AWS DynamoDBLocal distro:

http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html

Fixes: https://github.com/adorechic/rcredstash/issues/11