### PR TITLE
Adding --kms-key-id option in put

### DIFF
--- a/lib/cred_stash/cli.rb
+++ b/lib/cred_stash/cli.rb
@@ -8,9 +8,11 @@ module CredStash
     end
 
     desc "put [key name]", "Put a value for key name"
+    option :kms_key_id , :desc => "the KMS key-id of the master key to use. Defaults to alias/credstash"
     def put(name)
       value = Readline.readline("secret value> ")
-      CredStash.put(name, value)
+      kms_key_id = options[:kms_key_id] if options[:kms_key_id]
+      CredStash.put(name, value, kms_key_id: kms_key_id)
       puts "#{name} has stored."
     end
 


### PR DESCRIPTION
I do not know why option to specify KMS key-id is not supported by command line, but it is inconvenient in my situation. So I opened a simple pull request.

None of the above are critical, I'd appreciate if you can look into them when you have time.