### PR TITLE
Use DynamoDB pagination

### DIFF
--- a/spec/cred_stash/repository/dynamo_db_spec.rb
+++ b/spec/cred_stash/repository/dynamo_db_spec.rb
@@ -110,6 +110,34 @@ describe CredStash::Repository::DynamoDB do
       expect(item.name).to eq 'name'
       expect(item.version).to eq '0000001'
     end
+
+    context 'pagination' do
+      let(:item1) { { 'name' => 'abc', 'version' => '0000001' } }
+      let(:item2) { { 'name' => 'def', 'version' => '0000002' } }
+
+      before do
+        stub_client.stub_responses(:scan, -> (context) {
+          if context.params[:exclusive_start_key].nil?
+            { items: [item1], last_evaluated_key: item1 }
+          else
+            { items: [item2] }
+          end
+        })
+      end
+
+      it 'returns items' do
+        items = described_class.new(client: stub_client).list
+        expect(items.size).to eq 2
+
+        item = items[0]
+        expect(item.name).to eq 'abc'
+        expect(item.version).to eq '0000001'
+
+        item = items[1]
+        expect(item.name).to eq 'def'
+        expect(item.version).to eq '0000002'
+      end
+    end
   end
 
   describe '#select' do


### PR DESCRIPTION
DynamoDB `Scan` results are divided into pages of data that are 1 MB in size (or less).
In order to fetch all the data instead of first page only we need to examine `Scan` result
and send additional queries if needed.

https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Scan.html#Scan.Pagination