### PR TITLE
Allow the AWS API clients to be passed in when configuring

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ RCredStash uses [aws-sdk v2](https://github.com/aws/aws-sdk-ruby), so configurat
 ```ruby
 CredStash.configure do |config|
   config.table_name = 'your_dynamodb_table_name'
+
+  # Optional, if you want to modify them, like for Localstack.
+  config.dynamo_client = Aws::DynamoDB::Client.new
+  config.kms_client = Aws::KMS::Client.new
 end
 ```
 

--- a/lib/cred_stash/cipher_key.rb
+++ b/lib/cred_stash/cipher_key.rb
@@ -5,7 +5,7 @@ class CredStash::CipherKey
 
   attr_reader :data_key, :hmac_key, :wrapped_key
 
-  def self.generate(client: Aws::KMS::Client.new, kms_key_id: nil,
+  def self.generate(client: CredStash.config.kms_client, kms_key_id: nil,
                     context: {})
     res = client.generate_data_key(
       key_id: kms_key_id || DEFAULT_KMS_KEY_ID,
@@ -19,7 +19,7 @@ class CredStash::CipherKey
     )
   end
 
-  def self.decrypt(wrapped_key, client: Aws::KMS::Client.new, context: {})
+  def self.decrypt(wrapped_key, client: CredStash.config.kms_client, context: {})
     res = client.decrypt(ciphertext_blob: wrapped_key, encryption_context: context)
     new(
       data_key: res.plaintext[0...32],

--- a/lib/cred_stash/config.rb
+++ b/lib/cred_stash/config.rb
@@ -10,7 +10,7 @@ module CredStash
   end
 
   class Config
-    attr_accessor :table_name, :storage
+    attr_accessor :table_name, :storage, :kms_client, :dynamo_client
 
     def initialize
       reset!
@@ -19,6 +19,8 @@ module CredStash
     def reset!
       @table_name = 'credential-store'
       @storage = :dynamodb
+      @kms_client = Aws::KMS::Client.new
+      @dynamo_client = Aws::DynamoDB::Client.new
     end
   end
 end

--- a/lib/cred_stash/repository/dynamo_db.rb
+++ b/lib/cred_stash/repository/dynamo_db.rb
@@ -1,7 +1,7 @@
 module CredStash::Repository
   class DynamoDB
     def initialize(client: nil)
-      @client = client || Aws::DynamoDB::Client.new
+      @client = client || CredStash.config.dynamo_client
     end
 
     def get(name, version: nil)


### PR DESCRIPTION
## Problem

Our system has a lot of keys in Credstash. Since KMS gets instantiated on every key decryption call, this results in flooding the AWS IMDS metadata system and exceeding the 1024 packet per second limit. So app boot often results in exceptions, especially when running on a cron server where multiple app instantiations can occur at the same time.

Reference: https://repost.aws/knowledge-center/ec2-linux-metadata-retrieval

## Proposed solution

Allow the KMS client to be passed into the `CredStash::Config` object and provide one by default. This has the two-fold benefit of only instantiating the KMS client once on app start, and allowing the Gem user to provide a customized client for things like Localstack.

For consistency, I also did this for DynamoDB. That could be skipped if desired.

One thing I didn't do is rework `lib/cred_stash/repository.rb`. With the proposed change, `CredStash.config.storage` could be eliminated in favor of something like the following:
```ruby
CredStash.configure do |config|
  endpoint = ENV['DYNAMODB_URL'] || 'http://localhost:8000'
  config.dynamo_client = Aws::DynamoDB::Client.new(
    endpoint: endpoint,
  )
end
```
But I'd view that as a change to be done as part of a deprecation cycle if desired.

I'm happy to make any changes you might want to this if you are amenable to the change. The tests pass locally.