### PR TITLE
Set up GitHub Actions

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Ruby ${{ matrix.ruby-version }}
-        uses: ruby/setup-ruby@ec02537da5712d66d4d50a0f33b7eb52773b5ed1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
       - name: Install dependencies

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,0 +1,28 @@
+name: Ruby CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        # Currently supported Ruby versions as of 2024-04-03.
+        # See for current status: https://www.ruby-lang.org/en/downloads/branches/
+        ruby-version: ['3.3', '3.2', '3.1']
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Ruby ${{ matrix.ruby-version }}
+        uses: ruby/setup-ruby@ec02537da5712d66d4d50a0f33b7eb52773b5ed1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+      - name: Install dependencies
+        run: bundle install
+      - name: Run tests
+        run: bundle exec rake

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -25,4 +25,4 @@ jobs:
       - name: Install dependencies
         run: bundle install
       - name: Run tests
-        run: bundle exec rake
+        run: AWS_REGION=us-east-1 bundle exec rake

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-sudo: false
-language: ruby
-rvm:
-  - 2.3.1
-  - 2.2.5
-before_install: gem install bundler -v 1.12.5

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,7 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in rcredstash.gemspec
 gemspec
+
+# Needed to run tests.
+# Could be any of ox, oga, libxml, nokogiri or rexml
+gem 'rexml'

--- a/rcredstash.gemspec
+++ b/rcredstash.gemspec
@@ -24,6 +24,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'thor'
 
   spec.add_development_dependency "bundler", "~> 2.4"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.0"
 end

--- a/rcredstash.gemspec
+++ b/rcredstash.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'aws-sdk-dynamodb'
   spec.add_dependency 'thor'
 
-  spec.add_development_dependency "bundler", "~> 2.4"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.0"
 end


### PR DESCRIPTION
This transitions from the now defunct TravisCI to GitHub Actions. It also updates some development dependencies to support newer Ruby and tests against currently supported versions of Ruby.